### PR TITLE
Potential fix for code scanning alert no. 33: Prototype-polluting assignment

### DIFF
--- a/source/files/javascripts/prism_unminified.js
+++ b/source/files/javascripts/prism_unminified.js
@@ -259,6 +259,9 @@ var _ = _self.Prism = {
 
 		if (rest) {
 			for (var token in rest) {
+				if (token === '__proto__' || token === 'constructor' || token === 'prototype') {
+					continue;
+				}
 				grammar[token] = rest[token];
 			}
 


### PR DESCRIPTION
Potential fix for [https://github.com/cvquesty/openvox-docs/security/code-scanning/33](https://github.com/cvquesty/openvox-docs/security/code-scanning/33)

To fix the prototype pollution vulnerability, we need to prevent dangerous property names (`__proto__`, `constructor`, `prototype`) from being assigned to the `grammar` object. The best way to do this is to add a check inside the `for...in` loop on line 261, skipping any property names that match these dangerous keys. This preserves existing functionality while preventing prototype pollution. The change should be made in the `tokenize` function, specifically in the block that copies properties from `rest` to `grammar` (lines 261-263).

No new imports or external libraries are needed; a simple conditional check is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
